### PR TITLE
use karma's error formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,10 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
                     line = chalk.red(line) + '\n';
 
                     // add all browser in which the test failed with color yellow
-                    line += repeatString('  ', depth + 1) + chalk.italic.yellow(item.failed.join('\n' + repeatString('  ', depth + 1))) + '\n';
+                    for(var bi = 0; bi < item.failed.length; bi++) {
+                      var browserName = item.failed[bi];
+                      line += repeatString('  ', depth + 1) + chalk.italic.yellow(browserName) + '\n';
+                    }
 
                     // add the error log in red
                     line += chalk.red(formatError((item.log||[])[0], repeatString('  ',depth)));


### PR DESCRIPTION
The error stack trace will be filtered, so that instead of timestamped URLs it'll contain resolved source paths. Also indentation of the stacktrace is corrected.

with karma formatter:

```

FAILED TESTS:
  high level API
    .split()
        ✗ generates highcharts options with group counts
          PhantomJS 1.9.7 (Linux)
        AssertionError: expected { Object (xAxis) } to deeply equal { Object (xAxis, series) }
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/karma-sinon-chai/node_modules/chai/chai.js:918
            at assertEql (/home/artm/src/dpi/dashboards/dash.js/node_modules/karma-sinon-chai/node_modules/chai/chai.js:1354)
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/karma-sinon-chai/node_modules/chai/chai.js:3522
            at /home/artm/src/dpi/dashboards/dash.js/src/js/spec/seq_spec.js:160
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4336
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4724
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4815
            at next (/home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4649)
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4659
            at next (/home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4597)
            at /home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:4626
            at timeslice (/home/artm/src/dpi/dashboards/dash.js/node_modules/mocha/mocha.js:5733)
```

Same error without:

```
FAILED TESTS:
  high level API
    .split()
        ✗ generates highcharts options with group counts
          PhantomJS 1.9.7 (Linux)
        AssertionError: expected { Object (xAxis) } to deeply equal { Object (xAxis, series) }
    at http://localhost:9876/base/node_modules/karma-sinon-chai/node_modules/chai/chai.js?1381402002000:918
    at assertEql (http://localhost:9876/base/node_modules/karma-sinon-chai/node_modules/chai/chai.js?1381402002000:1354)
    at http://localhost:9876/base/node_modules/karma-sinon-chai/node_modules/chai/chai.js?1381402002000:3522
    at http://localhost:9876/base/src/js/spec/seq_spec.js?1398668518000:160
    at http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4336
    at http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4724
    at http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4815
    at next (http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4649)
    at http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4659
    at next (http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4597)
    at http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:4626
    at timeslice (http://localhost:9876/base/node_modules/mocha/mocha.js?1390426114000:5733)
```
