### PR TITLE
fix calculating describe items' success

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ var MochaReporter = function (baseReporterDecorator, config) {
             item.isRoot = depth === 0;
             item.type = 'describe';
             item.skipped = result.skipped;
-            item.success = item.success === undefined ? true : item.success && result.success;
+            item.success = (item.success === undefined ? true : item.success) && result.success;
 
             // it block
             if (depth === maxDepth) {


### PR DESCRIPTION
without this fix some items are marked as successful disregarding nested `it` items failures.
