### PR TITLE
Add option to abbreviate passing suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,20 @@ module.exports = function(config) {
 
     mochaReporter: {
       // If true, passing suites will only have their titles printed,
-      // and individual specs will be skipped. Default is false.
+      // and individual specs will be skipped. 'exceptFirst' will show
+      // the full spec on the first run, but abbreviate afterwards.
+      // This is useful if you run your tasks in a watcher and want to
+      // have the nice overview mocha reporter offers, but without the
+      // verbosity.
+      //
+      // Default is false.
       abbreviatePassing: false;
 
       // If true and abbreviatePassing is set, passing suites will be
       // skipped completely. Thus for a fully green suite, you will only
-      // get the summary. Default is false.
+      // get the summary.
+      //
+      // Default is false.
       abbreviateAggressively: false;
     }
 

--- a/index.js
+++ b/index.js
@@ -16,9 +16,15 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
     var self = this;
     var firstRun = true;
+    var verboseFirstRun = false;
 
     if (config.mochaReporter === undefined) {
         config.mochaReporter = {};
+    }
+
+    if (config.mochaReporter.abbreviatePassing === 'exceptFirst') {
+        verboseFirstRun = true;
+        config.mochaReporter.abbreviatePassing = false;
     }
 
     // disable chalk when colors is set to false
@@ -322,6 +328,10 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
                 printFailures(self.allResults);
             }
+        }
+
+        if (verboseFirstRun) {
+            config.mochaReporter.abbreviatePassing = true;
         }
     };
 };


### PR DESCRIPTION
If mochaReporter {abbreviatePassing: true } is set in the config,
fully-passing suites will only have their headings printed, and skip
sub-items. Suites with any failing tests will still be printed out in
full, so it's easy to see which parts exactly broke.
