### PR TITLE
Bump log-symbols version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     },
     "dependencies": {
         "chalk": "^0.5.1",
-        "log-symbols": "^1.0.0"
+        "log-symbols": "^1.0.1"
     }
 }


### PR DESCRIPTION
This incorporates log-symbols fix for hidden character in output.
