### PR TITLE
Updated license to be a valid SPDX license

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "karma-reporter",
         "mocha"
     ],
-    "license": "The MIT License (MIT)",
+    "license": "MIT",
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
Solves npm warning "license should be a valid SPDX license expression"