### PR TITLE
Changed some formatting to not start at newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
         var i, item;
 
         if (firstRun) {
-            self.write(chalk.underline.bold('\nStart:') + '\n');
+            self.write('\n' + chalk.underline.bold('Start:') + '\n');
             firstRun = false;
         }
 
@@ -302,7 +302,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
             self.totalTime += browser.lastResult.totalTime;
         });
 
-        self.write(chalk.green('\nFinished in ' + formatTimeInterval(self.totalTime) + ' / ' + formatTimeInterval(self.netTime) + '\n\n'));
+        self.write('\n' + chalk.green('Finished in ' + formatTimeInterval(self.totalTime) + ' / ' + formatTimeInterval(self.netTime) + '\n\n'));
 
         if (browsers.length > 0 && !results.disconnected) {
             self.write(chalk.underline.bold('SUMMARY:') + '\n');
@@ -320,7 +320,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
                 self.write(chalk.red(getLogSymbol(logSymbols.error) + ' ' + results.failed + ' tests failed\n'));
 
                 if (outputMode !== 'noFailures') {
-                    self.write(chalk.underline.bold('\nFAILED TESTS:') + '\n');
+                    self.write('\n' + chalk.underline.bold('FAILED TESTS:') + '\n');
                     printFailures(self.allResults);
                 }
             }


### PR DESCRIPTION
For a few lines, the reporter currently starts styling at the end of the previous line. This wouldn't normally be an issue, but my use case is to execute karma from another test runner. We indent the report output so as to help differentiate it from the parent runner. 