### PR TITLE
Fix multiline string diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
                 isCompleted = isCompleted && allChildItemsAreCompleted(item.items);
             }
         });
-        
+
         return isCompleted;
     }
 
@@ -360,6 +360,13 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
                             actual: actual,
                             expected: expected
                         };
+
+                        if (String(err.actual).match(/^".*"$/) && String(err.expected).match(/^".*"$/)) {
+                            try {
+                                err.actual = JSON.parse(err.actual);
+                                err.expected = JSON.parse(err.expected);
+                            } catch(e) {}
+                        }
 
                         // ensure that actual and expected are strings
                         if (!(utils.isString(actual) && utils.isString(expected))) {
@@ -511,7 +518,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
                 if (item.count === self.numberOfBrowsers) {
                     item.isCompleted = true;
-                    
+
                     // print results to output when test was ran through all browsers
                     if (outputMode !== 'minimal') {
                         print(self.allResults, depth);


### PR DESCRIPTION
Fix multiline string diffs by parsing the actual and expected values as JSON.

This seems to fix #61.  To ensure it's not breaking other types of diffing I'm not aware of, I added a rudimentary test to see if the actual and expected values are both JSON-encoded strings.

/cc @4kochi since you appear to be the maintainer :)