### PR TITLE
Fix disabling the divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ module.exports = function(config) {
 
 **Default:** 80 equals signs ('=')
 
-The string to output between multiple test runs. Set to empty string to disable
+The string to output between multiple test runs. Set to `false` or empty string to disable
 
 ```js
 // karma.conf.js

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
     var outputMode = config.mochaReporter.output || 'full';
     var ignoreSkipped = config.mochaReporter.ignoreSkipped || false;
-    var divider = config.mochaReporter.divider || '=';
-    divider = repeatString(divider, process.stdout.columns || 80);
+    var divider = config.mochaReporter.hasOwnProperty('divider') ? config.mochaReporter.divider : '='
+    divider = repeatString(divider || '', process.stdout.columns || 80);
 
     // disable chalk when colors is set to false
     chalk.enabled = config.colors !== false;


### PR DESCRIPTION
Allows disabling the divider by setting the divider option to `''` (as was already documented) or any other falsy value (also added to the README).

Fixes #68.