### PR TITLE
Adding symbols option to the reporter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,6 +219,24 @@ module.exports = function (grunt) {
                 detectBrowsers: {
                     enabled: false
                 }
+            },
+            symbols: {
+                configFile: 'demo/karma.conf.js',
+                browsers: ['PhantomJS'],
+                options: {
+                    files: ['demo/demo2.spec.js'],
+                    mochaReporter: {
+                        symbols: {
+                            success: '+',
+                            info: '#',
+                            warning: '!',
+                            error: 'x'
+                        }
+                    }
+                },
+                detectBrowsers: {
+                    enabled: false
+                }
             }
         }
     });
@@ -250,6 +268,7 @@ module.exports = function (grunt) {
     grunt.registerTask('ignoreSkipped', ['copy:demo', 'karma:ignoreSkipped']);
     grunt.registerTask('piped', ['copy:demo', 'shell:karma']);
     grunt.registerTask('colors', ['copy:demo', 'karma:colors']);
+    grunt.registerTask('symbols', ['copy:demo', 'karma:symbols']);
     grunt.registerTask('duplicate', ['copy:demo', 'karma:duplicate']);
     grunt.registerTask('reload', ['copy:demo', 'karma:reload']);
     grunt.registerTask('mocha', ['copy:demo', 'karma:mocha']);
@@ -265,6 +284,7 @@ module.exports = function (grunt) {
         'shell:karma',
         'karma:noColors',
         'karma:colors',
+        'karma:symbols',
         'karma:duplicate',
         'karma:mocha',
         'karma:concurrency',

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ module.exports = function(config) {
         info: 'bgGreen',
         warning: 'cyan',
         error: 'bgRed'
+      },
+      symbols: {
+        success: '+',
+        info: '#',
+        warning: '!',
+        error: 'x'
       }
     },
 

--- a/index.js
+++ b/index.js
@@ -50,24 +50,27 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
     // set color functions
     config.mochaReporter.colors = config.mochaReporter.colors || {};
 
+    // set symbol functions
+    config.mochaReporter.symbols = config.mochaReporter.symbols || {};
+
     // set diff output
     config.mochaReporter.showDiff = config.mochaReporter.showDiff || false;
 
     var colors = {
         success: {
-            symbol: symbols.success,
+            symbol: config.mochaReporter.symbols.success || symbols.success,
             print: chalk[config.mochaReporter.colors.success] || chalk.green
         },
         info: {
-            symbol: symbols.info,
+            symbol: config.mochaReporter.symbols.info || symbols.info,
             print: chalk[config.mochaReporter.colors.info] || chalk.grey
         },
         warning: {
-            symbol: symbols.warning,
+            symbol: config.mochaReporter.symbols.warning || symbols.warning,
             print: chalk[config.mochaReporter.colors.warning] || chalk.yellow
         },
         error: {
-            symbol: symbols.error,
+            symbol: config.mochaReporter.symbols.error || symbols.error,
             print: chalk[config.mochaReporter.colors.error] || chalk.red
         }
     };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "christian-fei",
         "Clay Anderson",
         "Minh Son Nguyen",
-        "Adam Craven"
+        "Adam Craven",
+        "Teddy Sterne"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Ability to define custom symbols for the reporter. This is useful on build servers or machines that are unable to read the special symbols. Allows the use of ascii characters for easier interpretation of the build scripts using displayable characters.

![image](https://cloud.githubusercontent.com/assets/2295908/17252270/0bd3330e-557a-11e6-80ce-19dfd911ce33.png)
