### PR TITLE
fix: log can be an empty array

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,7 +355,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
                     // add the error log in error color
                     item.log = item.log || [];
-                    var log = item.log.length ? item.log[0].split('\n') : '';
+                    var log = item.log.length ? item.log[0].split('\n') : [];
                     var linesToLog = config.mochaReporter.maxLogLines;
                     var ii = 0;
 

--- a/index.js
+++ b/index.js
@@ -355,7 +355,7 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
                     // add the error log in error color
                     item.log = item.log || [];
-                    var log = item.log[0].split('\n');
+                    var log = item.log.length ? item.log[0].split('\n') : '';
                     var linesToLog = config.mochaReporter.maxLogLines;
                     var ii = 0;
 


### PR DESCRIPTION
This fixes a problem when the log is empty:

```
[test/browserstack    ] Missing error handler on `socket`.
[test/browserstack    ] TypeError: Cannot read property 'split' of undefined
[test/browserstack    ]     at printFailures (/opt/atlassian/pipelines/agent/build/node_modules/karma-mocha-reporter/index.js:358:42)
[test/browserstack    ]     at printFailures (/opt/atlassian/pipelines/agent/build/node_modules/karma-mocha-reporter/index.js:417:17)
[test/browserstack    ]     at printFailures (/opt/atlassian/pipelines/agent/build/node_modules/karma-mocha-reporter/index.js:417:17)
[test/browserstack    ]     at self.onRunComplete (/opt/atlassian/pipelines/agent/build/node_modules/karma-mocha-reporter/index.js:621:21)
[test/browserstack    ]     at .<anonymous> (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/events.js:13:22)
[test/browserstack    ]     at emitTwo (events.js:111:20)
[test/browserstack    ]     at emit (events.js:191:7)
[test/browserstack    ]     at emitRunCompleteIfAllBrowsersDone (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/server.js:294:12)
[test/browserstack    ]     at .<anonymous> (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/server.js:325:7)
[test/browserstack    ]     at emitOne (events.js:96:13)
[test/browserstack    ]     at emit (events.js:188:7)
[test/browserstack    ]     at .<anonymous> (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/server.js:308:12)
[test/browserstack    ]     at emitTwo (events.js:111:20)
[test/browserstack    ]     at emit (events.js:191:7)
[test/browserstack    ]     at onComplete (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/browser.js:143:13)
[test/browserstack    ]     at Socket.<anonymous> (/opt/atlassian/pipelines/agent/build/node_modules/karma/lib/events.js:13:22)
```