### PR TITLE
Print wall clock time when karma is finished. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -594,7 +594,8 @@ var MochaReporter = function (baseReporterDecorator, formatError, config) {
 
         isRunCompleted = true;
 
-        self.write('\n' + colors.success.print('Finished in ' + formatTimeInterval(self.totalTime) + ' / ' + formatTimeInterval(self.netTime)));
+        self.write('\n' + colors.success.print('Finished in ' + formatTimeInterval(self.totalTime) + ' / ' +
+                   formatTimeInterval(self.netTime) + ' @ ' + new Date().toTimeString()));
         self.write('\n\n');
 
         if (browsers.length > 0 && !results.disconnected) {


### PR DESCRIPTION
This is handy when 'watching' to have confidence that the most recent test report reflects a recent save.