### PR TITLE
fix: update strip-ansi to use newer ansi-regex without vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
-  - '5'
-  - '6'
-  - '7'
-  - '8'
+  - '10'
   - 'stable'
+services:
+  - xvfb
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dependencies": {
         "chalk": "^2.1.0",
         "log-symbols": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "strip-ansi": "^6.0.1"
     },
     "peerDependencies": {
         "karma": ">=0.13"


### PR DESCRIPTION
BREAKING CHANGE: Require Node.js 8 as per https://github.com/chalk/strip-ansi/releases/tag/v6.0.0

Closes: #108